### PR TITLE
Fix issue #3: handle unterminated pipeline

### DIFF
--- a/shell/debug.go
+++ b/shell/debug.go
@@ -1,0 +1,16 @@
+package shell
+
+import "log"
+
+func (c *CommandLine) dumpParserObject(seq int) {
+	if len(c.lexicalScope)-1 < seq {
+		log.Fatalf("invalid debug target %d\n", seq)
+	}
+	for j := range c.expression[seq] {
+		log.Printf("lexicalScope[%d]: %v", seq, c.lexicalScope[seq])
+		log.Printf("expression[%d]: %v", seq, c.expression[seq])
+		log.Printf("expression[%d][%d]: %v", seq, j, c.expression[seq][j])
+		log.Printf("cmd path %d: %s", seq, c.command[seq].Path)
+		log.Printf("args %d: %v", seq, c.command[seq].Args)
+	}
+}

--- a/shell/error_handlers.go
+++ b/shell/error_handlers.go
@@ -23,7 +23,7 @@ func (c *CommandLine) DumpErrors() (isNotNilArray error) {
 				isNotNilArray = e
 			}
 			if c.Debug {
-				_, _ = fmt.Fprintf(os.Stderr, "%v", e)
+				_, _ = fmt.Fprintf(os.Stderr, "%v\n", e)
 			}
 		}
 	}

--- a/shell/parse.go
+++ b/shell/parse.go
@@ -10,7 +10,7 @@ func (c *CommandLine) Parse() (err error) {
 		return err
 	}
 	if c.isBlankLine() {
-		return c.TerminateLine(false)
+		return c.TerminateLine()
 	} else {
 		c.evaluateStatement(c.GetInput())
 	}

--- a/shell/parse_command_test.go
+++ b/shell/parse_command_test.go
@@ -5,12 +5,14 @@ import (
 )
 
 func (s *CommandLine) TestCommandLine_ParseCommandWithArgs(c *C) {
+	lexLength := len(s.lexicalScope)
+	expLength := len(s.expression)
 	s.parseCommand("ls", []string{"-l", "-n"})
 	if len(s.error) != 0 {
 		c.Fatal("parseCommand must not append new error object")
-	} else if len(s.lexicalScope) != 0 {
+	} else if len(s.lexicalScope) != lexLength {
 		c.Fatal("parseCommand must not change lexical scope length")
-	} else if len(s.expression) != 0 {
+	} else if len(s.expression) != expLength {
 		c.Fatal("parseCommand must not change expression length")
 	} else if len(s.command) == 0 {
 		c.Fatal("parseCommand must set a new command field")

--- a/shell/parse_statement.go
+++ b/shell/parse_statement.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bytes"
 	"io"
+	"log"
 	"os"
 )
 
@@ -15,7 +16,6 @@ func (c *CommandLine) parseStatement() error {
 		args    []string
 	)
 	for i := range c.lexicalScope {
-		//log.Printf("lexicalScope[%d]: %v", i, c.lexicalScope[i])
 
 		c.parseExpression(c.lexicalScope[i])
 
@@ -30,13 +30,16 @@ func (c *CommandLine) parseStatement() error {
 
 		c.parseCommand(cmdName, args)
 
-		// debugger
-		//log.Printf("expression[%d]: %v", i, c.expression[i])
-		//for j := range c.expression[i] {
-		//	log.Printf("expression[%d][%d]: %v", i, j, c.expression[i][j])
-		//}
-		//log.Printf("cmdName %d: %s", i, cmdName)
-		//log.Printf("args %d: %v", i, args)
+		// debug messages
+		if c.Debug {
+			log.Printf("lexicalScope[%d]: %v", i, c.lexicalScope[i])
+			log.Printf("expression[%d]: %v", i, c.expression[i])
+			for j := range c.expression[i] {
+				log.Printf("expression[%d][%d]: %v", i, j, c.expression[i][j])
+			}
+			log.Printf("cmdName %d: %s", i, cmdName)
+			log.Printf("args %d: %v", i, args)
+		}
 
 		c.track(c.command[i].Start())
 	}

--- a/shell/parse_statement_test.go
+++ b/shell/parse_statement_test.go
@@ -58,3 +58,11 @@ func (s *CommandLine) TestEvaluateInvalidCommand(c *C) {
 	sh.evaluateStatement("")
 	c.Check(sh.DumpErrors(), NotNil)
 }
+
+//fix #1 : unterminated pipeline makes error for parseStatement
+func (s *CommandLine) TestPipeEndError(c *C) {
+	sh := New()
+	sh.lexicalScope = []string{"ls -l", ""}
+	err := sh.parseStatement()
+	c.Check(err, NotNil)
+}

--- a/shell/run.go
+++ b/shell/run.go
@@ -26,6 +26,7 @@ func (c *CommandLine) Run() error {
 		err := c.Parse()
 		if err != nil {
 			fmt.Print(err)
+			_ = c.TerminateLine()
 		}
 	}
 

--- a/shell/run_test.go
+++ b/shell/run_test.go
@@ -2,16 +2,25 @@ package shell
 
 import ch "gopkg.in/check.v1"
 
-func (s *CommandLine) TestCommandLine_RunExitWithNil(c *ch.C) {
+func (s *CommandLine) TestRunExitWithNil(c *ch.C) {
 	sh := New()
 	if err := sh.Run(); err != nil {
 		c.Fatal(err)
 	}
 }
 
-func (s *CommandLine) TestCommandLine_RunWithInput(c *ch.C) {
+func (s *CommandLine) TestRunWithInput(c *ch.C) {
 	sh := New()
 	sh.input = "ls -l /"
+	if err := sh.Run(); err != nil {
+		c.Fatal(err)
+	}
+}
+
+//iss #1
+func (s *CommandLine) TestRunWithUnterminatedPipeError(c *ch.C) {
+	sh := New()
+	sh.input = "ls -l |"
 	if err := sh.Run(); err != nil {
 		c.Fatal(err)
 	}

--- a/shell/state_getters_test.go
+++ b/shell/state_getters_test.go
@@ -26,3 +26,18 @@ func (s *CommandLine) TestGetCurrentCommandNil(c *C) {
 	s.command = []*exec.Cmd{}
 	c.Check(s.getCurrentCommand(), IsNil)
 }
+
+func (s *CommandLine) TestBlankLine(c *C) {
+	s.lexicalScope = []string{"ls"}
+	s.expression = [][]string{{"ls"}}
+	c.Log("ls")
+	c.Check(s.isBlankLine(), Equals, false)
+	c.Log("[nospace]")
+	s.lexicalScope = []string{}
+	s.expression = [][]string{}
+	c.Check(s.isBlankLine(), Equals, true)
+	c.Log("[spaceX2]")
+	s.lexicalScope = []string{"  "}
+	s.expression = [][]string{{}}
+	c.Check(s.isBlankLine(), Equals, true)
+}


### PR DESCRIPTION
This pr fixes issue #3 . I checked now unterminated pipe makes error and the shell does not panic. 

The program makes no output but an error message when it encounters blank expression after `|`.

```
suzume@mock:~/local/Go/giosh$ ./giosh 
@G[1]> ls -l |
pipe error: pipeline #1 is nil
@G[2]> 
```